### PR TITLE
Refine migrations for base schema and hints

### DIFF
--- a/backend/alembic/versions/20250916_01_add_hints_table.py
+++ b/backend/alembic/versions/20250916_01_add_hints_table.py
@@ -1,7 +1,7 @@
 """add hints table
 
 Revision ID: 20250916_01_add_hints_table
-Revises: 
+Revises: 622a3a0b0cc2
 Create Date: 2025-09-16 00:00:00
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '20250916_01_add_hints_table'
-down_revision = None
+down_revision = '622a3a0b0cc2'
 branch_labels = None
 depends_on = None
 
@@ -19,19 +19,17 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         'hints',
-        sa.Column('id', sa.Integer(), primary_key=True, index=True),
-        sa.Column('assignment_id', sa.Integer(), sa.ForeignKey('assignments.id', ondelete='CASCADE'), nullable=False),
-        sa.Column('order_index', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('assignment_id', sa.Integer(), sa.ForeignKey('assignments.id'), nullable=False),
+        sa.Column('order_index', sa.Integer(), nullable=True, server_default=sa.text('0')),
         sa.Column('text', sa.Text(), nullable=False),
-        sa.Column('penalty', sa.Integer(), nullable=False, server_default='10'),
-        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('(CURRENT_TIMESTAMP)')),
-        sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.text('(CURRENT_TIMESTAMP)')),
+        sa.Column('penalty', sa.Integer(), nullable=True, server_default=sa.text('10')),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
     )
-    op.create_index('ix_hints_assignment_order', 'hints', ['assignment_id', 'order_index'], unique=True)
+    op.create_index(op.f('ix_hints_id'), 'hints', ['id'], unique=False)
 
 
 def downgrade() -> None:
-    op.drop_index('ix_hints_assignment_order', table_name='hints')
+    op.drop_index(op.f('ix_hints_id'), table_name='hints')
     op.drop_table('hints')
-
-

--- a/backend/alembic/versions/622a3a0b0cc2_create_courses_topics_assignments.py
+++ b/backend/alembic/versions/622a3a0b0cc2_create_courses_topics_assignments.py
@@ -1,0 +1,68 @@
+"""create courses topics assignments
+
+Revision ID: 622a3a0b0cc2
+Revises: None
+Create Date: 2025-09-20 21:43:40.905485
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '622a3a0b0cc2'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'courses',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('title', sa.String(length=200), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('duration_hours', sa.Integer(), nullable=True, server_default=sa.text('0')),
+        sa.Column('difficulty_level', sa.String(length=50), nullable=True, server_default=sa.text("'beginner'")),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+    op.create_index(op.f('ix_courses_id'), 'courses', ['id'], unique=False)
+
+    op.create_table(
+        'topics',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('title', sa.String(length=200), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('content', sa.Text(), nullable=False),
+        sa.Column('order_index', sa.Integer(), nullable=True, server_default=sa.text('0')),
+        sa.Column('duration_minutes', sa.Integer(), nullable=True, server_default=sa.text('0')),
+        sa.Column('course_id', sa.Integer(), sa.ForeignKey('courses.id'), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+    op.create_index(op.f('ix_topics_id'), 'topics', ['id'], unique=False)
+
+    op.create_table(
+        'assignments',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('title', sa.String(length=200), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('instructions', sa.Text(), nullable=False),
+        sa.Column('difficulty_level', sa.String(length=50), nullable=True, server_default=sa.text("'easy'")),
+        sa.Column('estimated_hours', sa.Integer(), nullable=True, server_default=sa.text('1')),
+        sa.Column('is_required', sa.Boolean(), nullable=True, server_default=sa.text('1')),
+        sa.Column('topic_id', sa.Integer(), sa.ForeignKey('topics.id'), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=True, server_default=sa.func.now()),
+    )
+    op.create_index(op.f('ix_assignments_id'), 'assignments', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_assignments_id'), table_name='assignments')
+    op.drop_table('assignments')
+    op.drop_index(op.f('ix_topics_id'), table_name='topics')
+    op.drop_table('topics')
+    op.drop_index(op.f('ix_courses_id'), table_name='courses')
+    op.drop_table('courses')


### PR DESCRIPTION
## Summary
- align the base Alembic revision with the ORM defaults by using SQL expressions for timestamps, booleans, and default strings
- update the hints migration to depend on the base revision and create its indexes explicitly without unsupported column arguments
- drop the extra unique index on hint ordering so the schema matches the ORM models

## Testing
- alembic -c backend/alembic.ini upgrade head
- python backend/init_db.py
- sqlite3 vibe_coding.db 'SELECT COUNT(*) FROM hints;'


------
https://chatgpt.com/codex/tasks/task_e_68cf1fc2d1148330829eba2e42bcf614